### PR TITLE
Fix blank screen issue [#18]

### DIFF
--- a/app/src/main/java/com/bytehamster/flowitgame/GLRenderer.java
+++ b/app/src/main/java/com/bytehamster/flowitgame/GLRenderer.java
@@ -69,8 +69,6 @@ public class GLRenderer implements Renderer {
         gl.glGenTextures(textures.length, textures, 0);
         loadTexture(gl, 0, textureDrawables[currentColorschemeIndex]);
 
-        gl.glLoadIdentity();
-
         debugOutput(gl);
     }
 

--- a/app/src/main/java/com/bytehamster/flowitgame/GLRenderer.java
+++ b/app/src/main/java/com/bytehamster/flowitgame/GLRenderer.java
@@ -69,6 +69,8 @@ public class GLRenderer implements Renderer {
         gl.glGenTextures(textures.length, textures, 0);
         loadTexture(gl, 0, textureDrawables[currentColorschemeIndex]);
 
+        gl.glLoadIdentity();
+
         debugOutput(gl);
     }
 
@@ -83,6 +85,7 @@ public class GLRenderer implements Renderer {
 
         gl.glBindTexture(GL10.GL_TEXTURE_2D, textures[0]);
         gl.glMatrixMode(GL10.GL_PROJECTION);
+        gl.glLoadIdentity();
         GLU.gluOrtho2D(gl, 0, width, 0, height);
         gl.glMatrixMode(GL10.GL_MODELVIEW);
         debugOutput(gl);


### PR DESCRIPTION
Fix #18, in which switching apps or turning the screen off and on results in a blank screen.

When Flowit launches, `onSurfaceChanged` is called once. But when it resumes, `onSurfaceChanged` is called twice. The loaded matrix previously was not reset between calls, meaning that the second `onSurfaceChanged` would mess up all the coordinates. Adding `gl.glLoadIdentity()` in `onSurfaceChanged` fixes the issue.

On my phone, if I unlock using pin instead of fingerprint sensor, the initial dimensions of the created surface change. Therefore, to fix the graphics appearing in a slightly incorrect position, another `gl.glLoadIdentity()` in `onSurfaceCreated` is applied. (This one I don't really understand, so I'm not sure if there's a better fix, but it seems to work in my testing).

I think these two changes resolve the blank screen problem, but I'm not an expert on OpenGL and there may be some other edge cases that it doesn't address.